### PR TITLE
REFACTOR : contents query

### DIFF
--- a/docs/contents/contents.swagger.ts
+++ b/docs/contents/contents.swagger.ts
@@ -7,6 +7,7 @@ import {
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
+import { ContentsDetailResponseDto } from 'src/domain/contents/dtos/contents-detail-response.dto';
 import { ContentsResponseDto } from 'src/domain/contents/dtos/contents-response.dto';
 
 export function GetContentsDocs() {
@@ -37,7 +38,7 @@ export function GetContentDetailDocs() {
       type: 'number',
       description: '게시물 id',
     }),
-    ApiOkResponse({ type: ContentsResponseDto }),
+    ApiOkResponse({ type: ContentsDetailResponseDto }),
   );
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,15 +18,13 @@ model Tags {
   tag_pk            Int               @id @unique @default(autoincrement())
   tag               String            @unique @db.VarChar(30)
   category_fk       Int
+  Contents          Contents[]
   ContentCategories ContentCategories @relation(fields: [category_fk], references: [category_pk], onDelete: Cascade, map: "category_fk")
   UserTags          UserTags[]
-  Contents          Contents[]
 }
 
 model Contents {
   content_pk        Int               @id @unique @default(autoincrement())
-  category          String            @db.VarChar(30)
-  tag               String            @db.VarChar(30)
   title             String            @db.VarChar(30)
   link              String            @db.VarChar(100)
   img               String            @db.VarChar(100)
@@ -39,6 +37,8 @@ model Contents {
   benefit           String[]
   created_at        DateTime          @default(now())
   updated_at        DateTime          @updatedAt
+  category          String            @db.VarChar(30)
+  tag               String            @db.VarChar(30)
   ContentCategories ContentCategories @relation(fields: [category], references: [category], onDelete: Cascade, map: "category_fk")
   Tags              Tags              @relation(fields: [tag], references: [tag], onDelete: Cascade, map: "tag_fk")
   Likes             Likes[]
@@ -78,8 +78,8 @@ model UserTags {
   user_tag_pk Int   @id @default(autoincrement())
   user_fk     Int
   tag_fk      Int
-  Users       Users @relation(fields: [user_fk], references: [user_pk])
   Tags        Tags  @relation(fields: [tag_fk], references: [tag_pk])
+  Users       Users @relation(fields: [user_fk], references: [user_pk])
 
   @@unique([user_fk, tag_fk], name: "users_tags")
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,3 +1,4 @@
+import { AuthModule } from './domain/auth/auth.module';
 import { ContentsModule } from './domain/contents/contents.module';
 import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { AppController } from './app.controller';
@@ -20,6 +21,7 @@ import { UserModule } from './domain/user/user.module';
     PrismaModule,
     UserModule,
     ContentsModule,
+    AuthModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/domain/contents/controller/contents.controller.ts
+++ b/src/domain/contents/controller/contents.controller.ts
@@ -18,7 +18,6 @@ export class ContentsController {
   async getContents(
     @Query() contentsRequestDto: GetContentsRequestDto,
   ): Promise<ContentsResponseDto[]> {
-    console.log(contentsRequestDto.filter);
     return this.contentsService.getContents(contentsRequestDto);
   }
 
@@ -27,6 +26,7 @@ export class ContentsController {
   async searchByKeyword(
     @Query('keyword') keyword: string,
   ): Promise<ContentsResponseDto[]> {
+    console.log('contentsController /search');
     return this.contentsService.searchByKeyword(keyword);
   }
 

--- a/src/domain/contents/controller/contents.controller.ts
+++ b/src/domain/contents/controller/contents.controller.ts
@@ -26,7 +26,6 @@ export class ContentsController {
   async searchByKeyword(
     @Query('keyword') keyword: string,
   ): Promise<ContentsResponseDto[]> {
-    console.log('contentsController /search');
     return this.contentsService.searchByKeyword(keyword);
   }
 

--- a/src/domain/contents/controller/contents.controller.ts
+++ b/src/domain/contents/controller/contents.controller.ts
@@ -1,5 +1,5 @@
 import { GetContentsRequestDto } from '../dtos/contents-request.dto';
-import { ContentsResponseDto } from '../dtos/contents-response.dto';
+import { ContentsDetailResponseDto } from '../dtos/contents-detail-response.dto';
 import { Controller, Get, Param, Query } from '@nestjs/common';
 import { ContentsService } from 'src/domain/contents/service/contents.service';
 import {
@@ -7,6 +7,7 @@ import {
   GetContentsDocs,
   SearchByKeywordDocs,
 } from 'docs/contents/contents.swagger';
+import { ContentsResponseDto } from '../dtos/contents-response.dto';
 
 @Controller('api/contents')
 export class ContentsController {
@@ -17,6 +18,7 @@ export class ContentsController {
   async getContents(
     @Query() contentsRequestDto: GetContentsRequestDto,
   ): Promise<ContentsResponseDto[]> {
+    console.log(contentsRequestDto.filter);
     return this.contentsService.getContents(contentsRequestDto);
   }
 
@@ -32,7 +34,7 @@ export class ContentsController {
   @GetContentDetailDocs()
   async getContentDetail(
     @Param('pk') pk: number,
-  ): Promise<ContentsResponseDto> {
+  ): Promise<ContentsDetailResponseDto> {
     return this.contentsService.getContentDetail(+pk);
   }
 }

--- a/src/domain/contents/dtos/contents-detail-response.dto.ts
+++ b/src/domain/contents/dtos/contents-detail-response.dto.ts
@@ -1,0 +1,110 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber } from 'class-validator';
+
+export class ContentsDetailResponseDto {
+  @ApiProperty({
+    type: Number,
+    required: true,
+    description: '게시물 id',
+  })
+  @IsNumber()
+  readonly content_pk: number;
+
+  @ApiProperty({
+    type: String,
+    nullable: false,
+    description: '게시물 제목',
+  })
+  readonly title: string;
+
+  @ApiProperty({
+    type: String,
+    nullable: false,
+    description: '게시물 카테고리',
+  })
+  readonly category: string;
+
+  @ApiProperty({
+    type: String,
+    nullable: false,
+    description: '게시물 태그',
+  })
+  readonly tag: string;
+
+  @ApiProperty({
+    type: String,
+    nullable: false,
+    description: '원본 사이트 링크',
+  })
+  readonly link: string;
+
+  @ApiProperty({
+    type: String,
+    nullable: false,
+    description: '메인 이미지 주소',
+  })
+  readonly img: string;
+
+  @ApiProperty({
+    type: String,
+    nullable: false,
+    description: '장소 정보',
+  })
+  readonly place: string;
+
+  @ApiProperty({
+    type: String,
+    nullable: false,
+    description: '활동 설명',
+  })
+  readonly introduction: string;
+
+  @ApiProperty({
+    type: String,
+    nullable: true,
+    description: '혜택 시작 일자',
+  })
+  readonly start_at: string;
+
+  @ApiProperty({
+    type: String,
+    nullable: true,
+    description: '혜택 종료 일자',
+  })
+  readonly end_at: string;
+
+  @ApiProperty({
+    type: String,
+    nullable: false,
+    description: '문의 정보',
+  })
+  readonly inquiry: string[];
+
+  @ApiProperty({
+    type: String,
+    nullable: false,
+    description: '참가비',
+  })
+  readonly price: string[];
+
+  @ApiProperty({
+    type: String,
+    nullable: false,
+    description: '청소년 혜택',
+  })
+  readonly benefit: string[];
+
+  @ApiProperty({
+    type: Date,
+    nullable: false,
+    description: '생성일자',
+  })
+  readonly created_at: Date;
+
+  @ApiProperty({
+    type: String,
+    nullable: false,
+    description: '수정 일자',
+  })
+  readonly updated_at: Date;
+}

--- a/src/domain/contents/dtos/contents-request.dto.ts
+++ b/src/domain/contents/dtos/contents-request.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsOptional } from 'class-validator';
 
 export enum CategoryFilter {
   취미 = '취미',
@@ -13,5 +14,7 @@ export class GetContentsRequestDto {
     description:
       'Filter(취미, 활동, 진로), 전체를 불러올땐 아무값도 안넣으면 됩니다.',
   })
+  @IsOptional()
+  @IsEnum(CategoryFilter)
   filter?: CategoryFilter;
 }

--- a/src/domain/contents/dtos/contents-response.dto.ts
+++ b/src/domain/contents/dtos/contents-response.dto.ts
@@ -20,9 +20,9 @@ export class ContentsResponseDto {
   @ApiProperty({
     type: String,
     nullable: false,
-    description: '원본 사이트 링크',
+    description: '게시물 카테고리',
   })
-  readonly link: string;
+  readonly category: string;
 
   @ApiProperty({
     type: String,
@@ -30,20 +30,6 @@ export class ContentsResponseDto {
     description: '메인 이미지 주소',
   })
   readonly img: string;
-
-  @ApiProperty({
-    type: String,
-    nullable: false,
-    description: '장소 정보',
-  })
-  readonly place: string;
-
-  @ApiProperty({
-    type: String,
-    nullable: false,
-    description: '활동 설명',
-  })
-  readonly introduction: string;
 
   @ApiProperty({
     type: String,
@@ -58,39 +44,4 @@ export class ContentsResponseDto {
     description: '혜택 종료 일자',
   })
   readonly end_at: string;
-
-  @ApiProperty({
-    type: String,
-    nullable: false,
-    description: '문의 정보',
-  })
-  readonly inquiry: string[];
-
-  @ApiProperty({
-    type: String,
-    nullable: false,
-    description: '참가비',
-  })
-  readonly price: string[];
-
-  @ApiProperty({
-    type: String,
-    nullable: false,
-    description: '청소년 혜택',
-  })
-  readonly benefit: string[];
-
-  @ApiProperty({
-    type: Date,
-    nullable: false,
-    description: '생성일자',
-  })
-  readonly created_at: Date;
-
-  @ApiProperty({
-    type: String,
-    nullable: false,
-    description: '수정 일자',
-  })
-  readonly updated_at: Date;
 }

--- a/src/domain/contents/repository/contents.repository.ts
+++ b/src/domain/contents/repository/contents.repository.ts
@@ -35,6 +35,7 @@ export class ContentsRepository {
         end_at: true,
       },
     });
+
     return contents;
   }
 
@@ -81,6 +82,7 @@ export class ContentsRepository {
         end_at: true,
       },
     });
+
     return contents;
   }
 

--- a/src/domain/contents/repository/contents.repository.ts
+++ b/src/domain/contents/repository/contents.repository.ts
@@ -1,8 +1,9 @@
 import { CategoryFilter } from './../dtos/contents-request.dto';
 import { Injectable } from '@nestjs/common';
 import { ContentCategories } from '@prisma/client';
-import { ContentsResponseDto } from 'src/domain/contents/dtos/contents-response.dto';
+import { ContentsDetailResponseDto } from 'src/domain/contents/dtos/contents-detail-response.dto';
 import { PrismaService } from 'src/global/prisma/prima.service';
+import { ContentsResponseDto } from '../dtos/contents-response.dto';
 
 @Injectable()
 export class ContentsRepository {
@@ -18,17 +19,36 @@ export class ContentsRepository {
     return category;
   }
 
-  async getFilteredContents(filter: CategoryFilter) {
+  async getFilteredContents(
+    filter: CategoryFilter,
+  ): Promise<ContentsResponseDto[]> {
     const contents = await this.prisma.contents.findMany({
       where: {
         category: filter,
+      },
+      select: {
+        content_pk: true,
+        title: true,
+        category: true,
+        img: true,
+        start_at: true,
+        end_at: true,
       },
     });
     return contents;
   }
 
-  async getAllContents() {
-    return this.prisma.contents.findMany();
+  async getAllContents(): Promise<ContentsResponseDto[]> {
+    return await this.prisma.contents.findMany({
+      select: {
+        content_pk: true,
+        title: true,
+        category: true,
+        img: true,
+        start_at: true,
+        end_at: true,
+      },
+    });
   }
 
   async searchByKeyword(keyword: string): Promise<ContentsResponseDto[]> {
@@ -52,11 +72,19 @@ export class ContentsRepository {
           },
         ],
       },
+      select: {
+        content_pk: true,
+        title: true,
+        category: true,
+        img: true,
+        start_at: true,
+        end_at: true,
+      },
     });
     return contents;
   }
 
-  async getContentDetail(pk: number) {
+  async getContentDetail(pk: number): Promise<ContentsDetailResponseDto> {
     const content = await this.prisma.contents.findUnique({
       where: {
         content_pk: pk,

--- a/src/domain/contents/service/contents.service.ts
+++ b/src/domain/contents/service/contents.service.ts
@@ -1,7 +1,8 @@
 import { ContentsRepository } from '../repository/contents.repository';
 import { GetContentsRequestDto } from '../dtos/contents-request.dto';
-import { ContentsResponseDto } from '../dtos/contents-response.dto';
+import { ContentsDetailResponseDto } from '../dtos/contents-detail-response.dto';
 import { Injectable, NotFoundException } from '@nestjs/common';
+import { ContentsResponseDto } from '../dtos/contents-response.dto';
 
 @Injectable()
 export class ContentsService {
@@ -30,7 +31,7 @@ export class ContentsService {
     return contents;
   }
 
-  async getContentDetail(pk: number): Promise<ContentsResponseDto> {
+  async getContentDetail(pk: number): Promise<ContentsDetailResponseDto> {
     const content = await this.contentsRepository.getContentDetail(pk);
 
     return content;

--- a/src/domain/user/user.module.ts
+++ b/src/domain/user/user.module.ts
@@ -4,7 +4,6 @@ import { UserService } from './service/user.service';
 import { UserRepository } from './repository/user.repository';
 
 @Module({
-  imports: [],
   controllers: [UserController],
   providers: [UserService, UserRepository],
 })


### PR DESCRIPTION
### 관련 이슈가 있다면 적어주세요.

## 📌 개발 이유
/contents
/contents/?filter=
/contents/search/?keyword=
세 개의 API에서 contents 테이블의 모든 column을 불러올 필요가 없다고 판단하였습니다

## 💻 수정 사항
prisma.schema, app.module 에서 병합되지 않은 부분 병합
Dto를 ContentsResponseDto와 ContentsDetailResponseDto로 나누고,
Query에 select문을 추가하였습니다
+ Swagger.docs update

## 🧪 테스트 방법

## ⛳️ 고민한 점 || 궁굼한 점

## 🎯 리뷰 포인트

## 📁 레퍼런스
