### PR TITLE
Feat/contents : 좋아요

### DIFF
--- a/docs/contents/contents.swagger.ts
+++ b/docs/contents/contents.swagger.ts
@@ -1,4 +1,3 @@
-import { ContentsLikeResponseDTO } from './../../src/domain/contents/dtos/contents-like-response.dto';
 import { applyDecorators } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
@@ -14,6 +13,7 @@ import {
 import { ContentsDetailResponseDto } from 'src/domain/contents/dtos/contents-detail-response.dto';
 import { ContentsResponseDto } from 'src/domain/contents/dtos/contents-response.dto';
 import { ResponseDto } from 'src/global/dtos/response.dto';
+import { ContentsLikedResponseDto } from 'src/domain/contents/dtos/contents-liked-response.dto';
 
 export function GetContentsDocs() {
   return applyDecorators(
@@ -94,7 +94,7 @@ export function LikeContentDocs() {
         example: ResponseDto.fail(400, 'token이 필요합니다.'),
       },
     }),
-    ApiOkResponse({ type: ContentsLikeResponseDTO }),
+    ApiOkResponse({ type: ContentsLikedResponseDto }),
   );
 }
 
@@ -168,6 +168,6 @@ export function GetLikedContentsDocs() {
       description:
         '좋아요를 누른 게시물이 없는 경우: 좋아요를 누른 (${contentsRequestDto.filter}) 게시물이 없습니다',
     }),
-    ApiOkResponse({ type: [ContentsResponseDto] }),
+    ApiOkResponse({ type: [ContentsLikedResponseDto] }),
   );
 }

--- a/docs/contents/contents.swagger.ts
+++ b/docs/contents/contents.swagger.ts
@@ -103,6 +103,8 @@ export function GetLikedContentsDocs() {
     ApiTags('ContentLike'),
     ApiOperation({
       summary: '좋아요 한 게시물 목록 조회',
+      description:
+        'Query가 들어오지 않을 시 전체를 조회하며, filter 이름의 쿼리 스트링이 들어올 시 카테고리가 일치하는 게시물만 조회됩니다',
     }),
     ApiHeader({
       name: 'Authorization',
@@ -111,6 +113,12 @@ export function GetLikedContentsDocs() {
       schema: {
         example: 'Authorization Bearer ${Access 토큰}',
       },
+    }),
+    ApiQuery({
+      name: 'filter',
+      type: 'string',
+      description: '카테고리명 (취미 / 진로 / 활동)',
+      required: false,
     }),
     ApiUnauthorizedResponse({
       description: 'access 토큰이 만료된 경우',
@@ -123,6 +131,10 @@ export function GetLikedContentsDocs() {
       schema: {
         example: ResponseDto.fail(400, 'token이 필요합니다.'),
       },
+    }),
+    ApiNotFoundResponse({
+      description:
+        '좋아요를 누른 게시물이 없는 경우: 좋아요를 누른 (${contentsRequestDto.filter}) 게시물이 없습니다',
     }),
     ApiOkResponse({ type: [ContentsResponseDto] }),
   );

--- a/docs/contents/contents.swagger.ts
+++ b/docs/contents/contents.swagger.ts
@@ -98,6 +98,38 @@ export function LikeContentDocs() {
   );
 }
 
+export function UnLikeContentDocs() {
+  return applyDecorators(
+    ApiTags('ContentLike'),
+    ApiOperation({
+      summary: '게시물 좋아요 취소',
+      description:
+        '여러 개의 게시물을 좋아요 취소할 때에는 parameter에 여러 pk를 ,로 분리하여 입력하시면 됩니다',
+    }),
+    ApiHeader({
+      name: 'Authorization',
+      description:
+        "access token이 필요합니다 key : Authorization, value : 'Bearer ${Token}'",
+      schema: {
+        example: 'Authorization Bearer ${Access 토큰}',
+      },
+    }),
+    ApiUnauthorizedResponse({
+      description: 'access 토큰이 만료된 경우',
+      schema: {
+        example: ResponseDto.fail(401, '만료된 token.'),
+      },
+    }),
+    ApiBadRequestResponse({
+      description: 'header에 토큰이 없는 경우 or token 값 자체가 이상한 경우',
+      schema: {
+        example: ResponseDto.fail(400, 'token이 필요합니다.'),
+      },
+    }),
+    ApiOkResponse(),
+  );
+}
+
 export function GetLikedContentsDocs() {
   return applyDecorators(
     ApiTags('ContentLike'),

--- a/docs/contents/contents.swagger.ts
+++ b/docs/contents/contents.swagger.ts
@@ -73,7 +73,6 @@ export function LikeContentDocs() {
     ApiTags('ContentLike'),
     ApiOperation({
       summary: '게시물 좋아요',
-      description: 'access 토큰으로 유저 정보를 조회합니다.',
     }),
     ApiHeader({
       name: 'Authorization',
@@ -96,5 +95,35 @@ export function LikeContentDocs() {
       },
     }),
     ApiOkResponse({ type: ContentsLikeResponseDTO }),
+  );
+}
+
+export function GetLikedContentsDocs() {
+  return applyDecorators(
+    ApiTags('ContentLike'),
+    ApiOperation({
+      summary: '좋아요 한 게시물 목록 조회',
+    }),
+    ApiHeader({
+      name: 'Authorization',
+      description:
+        "access token이 필요합니다 key : Authorization, value : 'Bearer ${Token}'",
+      schema: {
+        example: 'Authorization Bearer ${Access 토큰}',
+      },
+    }),
+    ApiUnauthorizedResponse({
+      description: 'access 토큰이 만료된 경우',
+      schema: {
+        example: ResponseDto.fail(401, '만료된 token.'),
+      },
+    }),
+    ApiBadRequestResponse({
+      description: 'header에 토큰이 없는 경우 or token 값 자체가 이상한 경우',
+      schema: {
+        example: ResponseDto.fail(400, 'token이 필요합니다.'),
+      },
+    }),
+    ApiOkResponse({ type: [ContentsResponseDto] }),
   );
 }

--- a/docs/contents/contents.swagger.ts
+++ b/docs/contents/contents.swagger.ts
@@ -1,21 +1,27 @@
+import { ContentsLikeResponseDTO } from './../../src/domain/contents/dtos/contents-like-response.dto';
 import { applyDecorators } from '@nestjs/common';
 import {
+  ApiBadRequestResponse,
+  ApiHeader,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
   ApiParam,
   ApiQuery,
   ApiTags,
+  ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { ContentsDetailResponseDto } from 'src/domain/contents/dtos/contents-detail-response.dto';
 import { ContentsResponseDto } from 'src/domain/contents/dtos/contents-response.dto';
+import { ResponseDto } from 'src/global/dtos/response.dto';
 
 export function GetContentsDocs() {
   return applyDecorators(
     ApiTags('Contents'),
     ApiOperation({
-      summary:
-        '게시물 전체조회 / 필터별 조회 API 입니다. Query가 들어오지 않을 시 전체를 조회하며, filter 이름의 쿼리 스트링이 들어올 시 카테고리가 일치하는 게시물만 조회됩니다',
+      summary: '게시물 전체조회 / 필터별 조회 API 입니다',
+      description:
+        'Query가 들어오지 않을 시 전체를 조회하며, filter 이름의 쿼리 스트링이 들어올 시 카테고리가 일치하는 게시물만 조회됩니다',
     }),
     ApiQuery({
       name: 'filter',
@@ -59,5 +65,36 @@ export function SearchByKeywordDocs() {
         "keyword가 포함된 게시물이 없을 때: 'Not found contents including keyword: ' + ${keyword}'",
     }),
     ApiOkResponse({ type: [ContentsResponseDto] }),
+  );
+}
+
+export function LikeContentDocs() {
+  return applyDecorators(
+    ApiTags('ContentLike'),
+    ApiOperation({
+      summary: '게시물 좋아요',
+      description: 'access 토큰으로 유저 정보를 조회합니다.',
+    }),
+    ApiHeader({
+      name: 'Authorization',
+      description:
+        "access token이 필요합니다 key : Authorization, value : 'Bearer ${Token}'",
+      schema: {
+        example: 'Authorization Bearer ${Access 토큰}',
+      },
+    }),
+    ApiUnauthorizedResponse({
+      description: 'access 토큰이 만료된 경우',
+      schema: {
+        example: ResponseDto.fail(401, '만료된 token.'),
+      },
+    }),
+    ApiBadRequestResponse({
+      description: 'header에 토큰이 없는 경우 or token 값 자체가 이상한 경우',
+      schema: {
+        example: ResponseDto.fail(400, 'token이 필요합니다.'),
+      },
+    }),
+    ApiOkResponse({ type: ContentsLikeResponseDTO }),
   );
 }

--- a/src/domain/contents/controller/contents.controller.ts
+++ b/src/domain/contents/controller/contents.controller.ts
@@ -9,6 +9,7 @@ import {
   GetLikedContentsDocs,
   LikeContentDocs,
   SearchByKeywordDocs,
+  UnLikeContentDocs,
 } from 'docs/contents/contents.swagger';
 import { ContentsResponseDto } from '../dtos/contents-response.dto';
 import { AccessTokenGuard } from 'src/domain/auth/guard/access-token.guard';
@@ -65,5 +66,17 @@ export class ContentsController {
     @Param('pk') pk: number,
   ): Promise<ContentsLikeResponseDTO> {
     return this.contentsService.likeContent(user.userPk, +pk);
+  }
+
+  @Get('/:pk/unlike')
+  @UseGuards(AccessTokenGuard)
+  @UnLikeContentDocs()
+  async unikeContent(
+    @User() user: JwtAuthUser,
+    @Param('pk') pk: string,
+  ): Promise<void> {
+    const contents = pk.split(',').map(Number);
+
+    return this.contentsService.unlikeContent(user.userPk, contents);
   }
 }

--- a/src/domain/contents/controller/contents.controller.ts
+++ b/src/domain/contents/controller/contents.controller.ts
@@ -1,4 +1,4 @@
-import { ContentsLikeResponseDTO } from './../dtos/contents-like-response.dto';
+import { LikeResponseDTO } from '../dtos/like-response.dto';
 import { GetContentsRequestDto } from '../dtos/contents-request.dto';
 import { ContentsDetailResponseDto } from '../dtos/contents-detail-response.dto';
 import { Controller, Get, Param, Query, UseGuards, Post } from '@nestjs/common';
@@ -14,6 +14,7 @@ import {
 import { ContentsResponseDto } from '../dtos/contents-response.dto';
 import { AccessTokenGuard } from 'src/domain/auth/guard/access-token.guard';
 import { JwtAuthUser, User } from 'src/global/decorators/jwt.decorator';
+import { ContentsLikedResponseDto } from '../dtos/contents-liked-response.dto';
 
 @Controller('api/contents')
 export class ContentsController {
@@ -25,16 +26,18 @@ export class ContentsController {
   async getContents(
     @User() user: JwtAuthUser,
     @Query() contentsRequestDto: GetContentsRequestDto,
-  ) {
+  ): Promise<ContentsResponseDto[]> {
     return this.contentsService.getContents(user.userPk, contentsRequestDto);
   }
 
   @Get('/search')
+  @UseGuards(AccessTokenGuard)
   @SearchByKeywordDocs()
   async searchByKeyword(
+    @User() user: JwtAuthUser,
     @Query('keyword') keyword: string,
   ): Promise<ContentsResponseDto[]> {
-    return this.contentsService.searchByKeyword(keyword);
+    return this.contentsService.searchByKeyword(user.userPk, keyword);
   }
 
   @Get('/liked')
@@ -43,7 +46,7 @@ export class ContentsController {
   async getLikedContent(
     @User() user: JwtAuthUser,
     @Query() contentsRequestDto: GetContentsRequestDto,
-  ): Promise<ContentsResponseDto[]> {
+  ): Promise<ContentsLikedResponseDto[]> {
     return this.contentsService.getLikedContents(
       user.userPk,
       contentsRequestDto,
@@ -51,11 +54,13 @@ export class ContentsController {
   }
 
   @Get('/:pk')
+  @UseGuards(AccessTokenGuard)
   @GetContentDetailDocs()
   async getContentDetail(
+    @User() user: JwtAuthUser,
     @Param('pk') pk: number,
   ): Promise<ContentsDetailResponseDto> {
-    return this.contentsService.getContentDetail(+pk);
+    return this.contentsService.getContentDetail(user.userPk, +pk);
   }
 
   @Post('/:pk/like')
@@ -64,7 +69,7 @@ export class ContentsController {
   async likeContent(
     @User() user: JwtAuthUser,
     @Param('pk') pk: number,
-  ): Promise<ContentsLikeResponseDTO> {
+  ): Promise<LikeResponseDTO> {
     return this.contentsService.likeContent(user.userPk, +pk);
   }
 

--- a/src/domain/contents/controller/contents.controller.ts
+++ b/src/domain/contents/controller/contents.controller.ts
@@ -1,13 +1,17 @@
+import { ContentsLikeResponseDTO } from './../dtos/contents-like-response.dto';
 import { GetContentsRequestDto } from '../dtos/contents-request.dto';
 import { ContentsDetailResponseDto } from '../dtos/contents-detail-response.dto';
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
 import { ContentsService } from 'src/domain/contents/service/contents.service';
 import {
   GetContentDetailDocs,
   GetContentsDocs,
+  LikeContentDocs,
   SearchByKeywordDocs,
 } from 'docs/contents/contents.swagger';
 import { ContentsResponseDto } from '../dtos/contents-response.dto';
+import { AccessTokenGuard } from 'src/domain/auth/guard/access-token.guard';
+import { JwtAuthUser, User } from 'src/global/decorators/jwt.decorator';
 
 @Controller('api/contents')
 export class ContentsController {
@@ -35,5 +39,15 @@ export class ContentsController {
     @Param('pk') pk: number,
   ): Promise<ContentsDetailResponseDto> {
     return this.contentsService.getContentDetail(+pk);
+  }
+
+  @Get('/:pk/like')
+  @UseGuards(AccessTokenGuard)
+  @LikeContentDocs()
+  async likeContent(
+    @User() user: JwtAuthUser,
+    @Param('pk') pk: number,
+  ): Promise<ContentsLikeResponseDTO> {
+    return this.contentsService.likeContent(user.userPk, +pk);
   }
 }

--- a/src/domain/contents/controller/contents.controller.ts
+++ b/src/domain/contents/controller/contents.controller.ts
@@ -1,7 +1,7 @@
 import { ContentsLikeResponseDTO } from './../dtos/contents-like-response.dto';
 import { GetContentsRequestDto } from '../dtos/contents-request.dto';
 import { ContentsDetailResponseDto } from '../dtos/contents-detail-response.dto';
-import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, Query, UseGuards, Post } from '@nestjs/common';
 import { ContentsService } from 'src/domain/contents/service/contents.service';
 import {
   GetContentDetailDocs,
@@ -58,7 +58,7 @@ export class ContentsController {
     return this.contentsService.getContentDetail(+pk);
   }
 
-  @Get('/:pk/like')
+  @Post('/:pk/like')
   @UseGuards(AccessTokenGuard)
   @LikeContentDocs()
   async likeContent(
@@ -68,7 +68,7 @@ export class ContentsController {
     return this.contentsService.likeContent(user.userPk, +pk);
   }
 
-  @Get('/:pk/unlike')
+  @Post('/:pk/unlike')
   @UseGuards(AccessTokenGuard)
   @UnLikeContentDocs()
   async unikeContent(

--- a/src/domain/contents/controller/contents.controller.ts
+++ b/src/domain/contents/controller/contents.controller.ts
@@ -6,6 +6,7 @@ import { ContentsService } from 'src/domain/contents/service/contents.service';
 import {
   GetContentDetailDocs,
   GetContentsDocs,
+  GetLikedContentsDocs,
   LikeContentDocs,
   SearchByKeywordDocs,
 } from 'docs/contents/contents.swagger';
@@ -18,11 +19,13 @@ export class ContentsController {
   constructor(private readonly contentsService: ContentsService) {}
 
   @Get('')
+  @UseGuards(AccessTokenGuard)
   @GetContentsDocs()
   async getContents(
+    @User() user: JwtAuthUser,
     @Query() contentsRequestDto: GetContentsRequestDto,
-  ): Promise<ContentsResponseDto[]> {
-    return this.contentsService.getContents(contentsRequestDto);
+  ) {
+    return this.contentsService.getContents(user.userPk, contentsRequestDto);
   }
 
   @Get('/search')
@@ -31,6 +34,15 @@ export class ContentsController {
     @Query('keyword') keyword: string,
   ): Promise<ContentsResponseDto[]> {
     return this.contentsService.searchByKeyword(keyword);
+  }
+
+  @Get('/liked')
+  @UseGuards(AccessTokenGuard)
+  @GetLikedContentsDocs()
+  async getLikedContent(
+    @User() user: JwtAuthUser,
+  ): Promise<ContentsResponseDto[]> {
+    return this.contentsService.getLikedContents(user.userPk);
   }
 
   @Get('/:pk')

--- a/src/domain/contents/controller/contents.controller.ts
+++ b/src/domain/contents/controller/contents.controller.ts
@@ -80,6 +80,8 @@ export class ContentsController {
     @User() user: JwtAuthUser,
     @Param('pk') pk: string,
   ): Promise<void> {
+    //! number type에 대한 검증 필요
+    //! validation 시 복잡하면 BODY로 넘기기
     const contents = pk.split(',').map(Number);
 
     return this.contentsService.unlikeContent(user.userPk, contents);

--- a/src/domain/contents/controller/contents.controller.ts
+++ b/src/domain/contents/controller/contents.controller.ts
@@ -41,8 +41,12 @@ export class ContentsController {
   @GetLikedContentsDocs()
   async getLikedContent(
     @User() user: JwtAuthUser,
+    @Query() contentsRequestDto: GetContentsRequestDto,
   ): Promise<ContentsResponseDto[]> {
-    return this.contentsService.getLikedContents(user.userPk);
+    return this.contentsService.getLikedContents(
+      user.userPk,
+      contentsRequestDto,
+    );
   }
 
   @Get('/:pk')

--- a/src/domain/contents/dtos/contents-like-response.dto.ts
+++ b/src/domain/contents/dtos/contents-like-response.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber } from 'class-validator';
+
+export class ContentsLikeResponseDTO {
+  @ApiProperty({
+    type: Number,
+    required: true,
+    description: '게시물 id',
+  })
+  @IsNumber()
+  readonly liked_pk: number;
+
+  @ApiProperty({
+    type: Number,
+    required: true,
+    description: '게시물 id',
+  })
+  @IsNumber()
+  readonly user: number;
+
+  @ApiProperty({
+    type: Number,
+    required: true,
+    description: '게시물 id',
+  })
+  @IsNumber()
+  readonly content: number;
+}

--- a/src/domain/contents/dtos/contents-liked-response.dto.ts
+++ b/src/domain/contents/dtos/contents-liked-response.dto.ts
@@ -1,30 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber } from 'class-validator';
 
-export class Like {
-  @ApiProperty({
-    type: Number,
-    nullable: false,
-    description: '좋아요 정보 key',
-  })
-  readonly liked_pk: number;
-
-  @ApiProperty({
-    type: Number,
-    nullable: false,
-    description: '좋아요 누른 유저 Pk',
-  })
-  readonly user: number;
-
-  @ApiProperty({
-    type: Number,
-    nullable: false,
-    description: '좋아요 눌린 게시물 Pk',
-  })
-  readonly content: number;
-}
-
-export class ContentsResponseDto {
+export class ContentsLikedResponseDto {
   @ApiProperty({
     type: Number,
     required: true,
@@ -67,11 +44,4 @@ export class ContentsResponseDto {
     description: '혜택 종료 일자',
   })
   readonly end_at: string;
-
-  @ApiProperty({
-    type: [Like],
-    nullable: false,
-    description: '좋아요 정보(없을 경우 빈 리스트)',
-  })
-  readonly Likes: Like[];
 }

--- a/src/domain/contents/dtos/like-response.dto.ts
+++ b/src/domain/contents/dtos/like-response.dto.ts
@@ -1,28 +1,24 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNumber } from 'class-validator';
 
-export class ContentsLikeResponseDTO {
+export class LikeResponseDTO {
   @ApiProperty({
     type: Number,
     required: true,
-    description: '게시물 id',
+    description: 'liked pk',
   })
-  @IsNumber()
   readonly liked_pk: number;
 
   @ApiProperty({
     type: Number,
     required: true,
-    description: '게시물 id',
+    description: 'user pk',
   })
-  @IsNumber()
   readonly user: number;
 
   @ApiProperty({
     type: Number,
     required: true,
-    description: '게시물 id',
+    description: 'content pk',
   })
-  @IsNumber()
   readonly content: number;
 }

--- a/src/domain/contents/repository/contents.repository.ts
+++ b/src/domain/contents/repository/contents.repository.ts
@@ -124,4 +124,30 @@ export class ContentsRepository {
 
     return like;
   }
+
+  async getLikedContents(user: number): Promise<ContentsResponseDto[]> {
+    const contents = await this.prisma.likes.findMany({
+      where: {
+        user,
+      },
+      include: {
+        Contents: {
+          select: {
+            content_pk: true,
+            title: true,
+            category: true,
+            img: true,
+            start_at: true,
+            end_at: true,
+          },
+        },
+      },
+    });
+
+    const result = contents.map((content) => {
+      return content.Contents;
+    });
+
+    return result;
+  }
 }

--- a/src/domain/contents/repository/contents.repository.ts
+++ b/src/domain/contents/repository/contents.repository.ts
@@ -1,9 +1,10 @@
 import { CategoryFilter } from './../dtos/contents-request.dto';
-import { Injectable } from '@nestjs/common';
+import { Injectable, BadRequestException } from '@nestjs/common';
 import { ContentCategories } from '@prisma/client';
 import { ContentsDetailResponseDto } from 'src/domain/contents/dtos/contents-detail-response.dto';
 import { PrismaService } from 'src/global/prisma/prima.service';
 import { ContentsResponseDto } from '../dtos/contents-response.dto';
+import { ContentsLikeResponseDTO } from '../dtos/contents-like-response.dto';
 
 @Injectable()
 export class ContentsRepository {
@@ -94,5 +95,33 @@ export class ContentsRepository {
     });
 
     return content;
+  }
+
+  async isLiked(
+    user: number,
+    content: number,
+  ): Promise<ContentsLikeResponseDTO> {
+    const liked = await this.prisma.likes.findFirst({
+      where: {
+        user,
+        content,
+      },
+    });
+
+    return liked;
+  }
+
+  async likeContent(
+    user: number,
+    content: number,
+  ): Promise<ContentsLikeResponseDTO> {
+    const like = await this.prisma.likes.create({
+      data: {
+        user,
+        content,
+      },
+    });
+
+    return like;
   }
 }

--- a/src/domain/contents/repository/contents.repository.ts
+++ b/src/domain/contents/repository/contents.repository.ts
@@ -140,30 +140,27 @@ export class ContentsRepository {
     user: number,
     filter: string,
   ): Promise<ContentsResponseDto[]> {
-    const contents = await this.prisma.contents.findMany({
+    const contents = await this.prisma.likes.findMany({
       where: {
-        category: filter,
+        user,
       },
-      select: {
-        content_pk: true,
-        title: true,
-        category: true,
-        img: true,
-        start_at: true,
-        end_at: true,
-        Likes: {
-          where: {
-            user,
+      include: {
+        Contents: {
+          select: {
+            content_pk: true,
+            title: true,
+            category: true,
+            img: true,
+            start_at: true,
+            end_at: true,
           },
         },
       },
     });
 
-    const result = contents.map((content) => {
-      if (content.Likes[0]) {
-        return content;
-      }
-    });
+    const result = contents
+      .filter((content) => content.Contents.category === filter)
+      .map((content) => content.Contents);
 
     return result;
   }

--- a/src/domain/contents/repository/contents.repository.ts
+++ b/src/domain/contents/repository/contents.repository.ts
@@ -151,10 +151,12 @@ export class ContentsRepository {
 
   async unlikeContent(user: number, contents: number[]): Promise<void> {
     for (const content of contents) {
-      await this.prisma.likes.deleteMany({
+      await this.prisma.likes.delete({
         where: {
-          user,
-          content,
+          likes_userid: {
+            user,
+            content,
+          },
         },
       });
     }
@@ -167,6 +169,9 @@ export class ContentsRepository {
     const contents = await this.prisma.likes.findMany({
       where: {
         user,
+        Contents: {
+          category: filter,
+        },
       },
       select: {
         Contents: {
@@ -182,9 +187,7 @@ export class ContentsRepository {
       },
     });
 
-    const result = contents
-      .filter((content) => content.Contents.category === filter)
-      .map((content) => content.Contents);
+    const result = contents.map((content) => content.Contents);
 
     return result;
   }

--- a/src/domain/contents/repository/contents.repository.ts
+++ b/src/domain/contents/repository/contents.repository.ts
@@ -125,6 +125,17 @@ export class ContentsRepository {
     return like;
   }
 
+  async unlikeContent(user: number, contents: number[]): Promise<void> {
+    for (const content of contents) {
+      await this.prisma.likes.deleteMany({
+        where: {
+          user,
+          content,
+        },
+      });
+    }
+  }
+
   async getFilteredLikedContents(
     user: number,
     filter: string,

--- a/src/domain/contents/repository/contents.repository.ts
+++ b/src/domain/contents/repository/contents.repository.ts
@@ -125,6 +125,38 @@ export class ContentsRepository {
     return like;
   }
 
+  async getFilteredLikedContents(
+    user: number,
+    filter: string,
+  ): Promise<ContentsResponseDto[]> {
+    const contents = await this.prisma.contents.findMany({
+      where: {
+        category: filter,
+      },
+      select: {
+        content_pk: true,
+        title: true,
+        category: true,
+        img: true,
+        start_at: true,
+        end_at: true,
+        Likes: {
+          where: {
+            user,
+          },
+        },
+      },
+    });
+
+    const result = contents.map((content) => {
+      if (content.Likes[0]) {
+        return content;
+      }
+    });
+
+    return result;
+  }
+
   async getLikedContents(user: number): Promise<ContentsResponseDto[]> {
     const contents = await this.prisma.likes.findMany({
       where: {

--- a/src/domain/contents/service/contents.service.ts
+++ b/src/domain/contents/service/contents.service.ts
@@ -7,7 +7,8 @@ import {
   BadRequestException,
 } from '@nestjs/common';
 import { ContentsResponseDto } from '../dtos/contents-response.dto';
-import { ContentsLikeResponseDTO } from '../dtos/contents-like-response.dto';
+import { LikeResponseDTO } from '../dtos/like-response.dto';
+import { ContentsLikedResponseDto } from '../dtos/contents-liked-response.dto';
 
 @Injectable()
 export class ContentsService {
@@ -16,16 +17,23 @@ export class ContentsService {
   async getContents(user: number, contentsRequestDto: GetContentsRequestDto) {
     if (contentsRequestDto.filter) {
       const contents = await this.contentsRepository.getFilteredContents(
+        user,
         contentsRequestDto.filter,
       );
       return contents;
     }
 
-    return await this.contentsRepository.getAllContents();
+    return await this.contentsRepository.getAllContents(user);
   }
 
-  async searchByKeyword(keyword: string): Promise<ContentsResponseDto[]> {
-    const contents = await this.contentsRepository.searchByKeyword(keyword);
+  async searchByKeyword(
+    user: number,
+    keyword: string,
+  ): Promise<ContentsResponseDto[]> {
+    const contents = await this.contentsRepository.searchByKeyword(
+      user,
+      keyword,
+    );
     if (!contents[0]) {
       throw new NotFoundException(
         'Not found contents including keyword: ' + keyword,
@@ -37,7 +45,7 @@ export class ContentsService {
   async getLikedContents(
     user: number,
     contentsRequestDto: GetContentsRequestDto,
-  ): Promise<ContentsResponseDto[]> {
+  ): Promise<ContentsLikedResponseDto[]> {
     if (contentsRequestDto.filter) {
       const contents = await this.contentsRepository.getFilteredLikedContents(
         user,
@@ -62,16 +70,16 @@ export class ContentsService {
     return contents;
   }
 
-  async getContentDetail(pk: number): Promise<ContentsDetailResponseDto> {
-    const content = await this.contentsRepository.getContentDetail(pk);
+  async getContentDetail(
+    user: number,
+    pk: number,
+  ): Promise<ContentsDetailResponseDto> {
+    const content = await this.contentsRepository.getContentDetail(user, pk);
 
     return content;
   }
 
-  async likeContent(
-    user: number,
-    content: number,
-  ): Promise<ContentsLikeResponseDTO> {
+  async likeContent(user: number, content: number): Promise<LikeResponseDTO> {
     const liked = await this.contentsRepository.isLiked(user, content);
 
     if (!liked) {

--- a/src/domain/contents/service/contents.service.ts
+++ b/src/domain/contents/service/contents.service.ts
@@ -1,8 +1,13 @@
 import { ContentsRepository } from '../repository/contents.repository';
 import { GetContentsRequestDto } from '../dtos/contents-request.dto';
 import { ContentsDetailResponseDto } from '../dtos/contents-detail-response.dto';
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
 import { ContentsResponseDto } from '../dtos/contents-response.dto';
+import { ContentsLikeResponseDTO } from '../dtos/contents-like-response.dto';
 
 @Injectable()
 export class ContentsService {
@@ -35,5 +40,19 @@ export class ContentsService {
     const content = await this.contentsRepository.getContentDetail(pk);
 
     return content;
+  }
+
+  async likeContent(
+    user: number,
+    content: number,
+  ): Promise<ContentsLikeResponseDTO> {
+    const liked = await this.contentsRepository.isLiked(user, content);
+
+    if (!liked) {
+      const like = await this.contentsRepository.likeContent(user, content);
+      return like;
+    }
+
+    throw new BadRequestException('already liked');
   }
 }

--- a/src/domain/contents/service/contents.service.ts
+++ b/src/domain/contents/service/contents.service.ts
@@ -44,7 +44,7 @@ export class ContentsService {
         contentsRequestDto.filter,
       );
 
-      if (contents[0] == null) {
+      if (!contents[0]) {
         throw new NotFoundException(
           `좋아요를 누른 ${contentsRequestDto.filter} 게시물이 없습니다`,
         );

--- a/src/domain/contents/service/contents.service.ts
+++ b/src/domain/contents/service/contents.service.ts
@@ -81,4 +81,8 @@ export class ContentsService {
 
     throw new BadRequestException('already liked');
   }
+
+  async unlikeContent(user: number, content: number[]): Promise<void> {
+    return await this.contentsRepository.unlikeContent(user, content);
+  }
 }

--- a/src/domain/contents/service/contents.service.ts
+++ b/src/domain/contents/service/contents.service.ts
@@ -13,9 +13,7 @@ import { ContentsLikeResponseDTO } from '../dtos/contents-like-response.dto';
 export class ContentsService {
   constructor(private readonly contentsRepository: ContentsRepository) {}
 
-  async getContents(
-    contentsRequestDto: GetContentsRequestDto,
-  ): Promise<ContentsResponseDto[]> {
+  async getContents(user: number, contentsRequestDto: GetContentsRequestDto) {
     if (contentsRequestDto.filter) {
       const contents = await this.contentsRepository.getFilteredContents(
         contentsRequestDto.filter,
@@ -34,6 +32,11 @@ export class ContentsService {
       );
     }
     return contents;
+  }
+
+  async getLikedContents(user: number): Promise<ContentsResponseDto[]> {
+    const likedContents = this.contentsRepository.getLikedContents(user);
+    return likedContents;
   }
 
   async getContentDetail(pk: number): Promise<ContentsDetailResponseDto> {

--- a/src/domain/contents/service/contents.service.ts
+++ b/src/domain/contents/service/contents.service.ts
@@ -34,9 +34,32 @@ export class ContentsService {
     return contents;
   }
 
-  async getLikedContents(user: number): Promise<ContentsResponseDto[]> {
-    const likedContents = this.contentsRepository.getLikedContents(user);
-    return likedContents;
+  async getLikedContents(
+    user: number,
+    contentsRequestDto: GetContentsRequestDto,
+  ): Promise<ContentsResponseDto[]> {
+    if (contentsRequestDto.filter) {
+      const contents = await this.contentsRepository.getFilteredLikedContents(
+        user,
+        contentsRequestDto.filter,
+      );
+
+      if (contents[0] == null) {
+        throw new NotFoundException(
+          `좋아요를 누른 ${contentsRequestDto.filter} 게시물이 없습니다`,
+        );
+      }
+
+      return contents;
+    }
+
+    const contents = await this.contentsRepository.getLikedContents(user);
+
+    if (!contents[0]) {
+      throw new NotFoundException(`좋아요를 누른 게시물이 없습니다`);
+    }
+
+    return contents;
   }
 
   async getContentDetail(pk: number): Promise<ContentsDetailResponseDto> {


### PR DESCRIPTION
### 관련 이슈가 있다면 적어주세요.
/api/contents/:pk/unlike
해당 api 에 parameter validation 로직 추가 필요
parameter로 제공받던 pk 리스트가 request body로 옮겨질 수 있습니다

## 📌 개발 이유

## 💻 수정 사항
Add : 
/api/contents/:pk/llike : 게시글 좋아요 
/api/contents/liked : 유저별 좋아요 누른 게시물 리스트 제공 (카테고리별 필터링 가능)
/api/contents/:pk/unlike 게시글 좋아요 취소 

Update:
/api/contents
/api/contents/search
해당 두 api에 좋아요 여부를 함께 return하도록 update 했습니다

## 🧪 테스트 방법

## ⛳️ 고민한 점 || 궁굼한 점

## 🎯 리뷰 포인트

## 📁 레퍼런스
