### PR TITLE
Fix: tag 공통 response dto 추가

### DIFF
--- a/docs/api.success.response.ts
+++ b/docs/api.success.response.ts
@@ -1,0 +1,60 @@
+import { Type, applyDecorators } from '@nestjs/common';
+import { ApiExtraModels, ApiOkResponse, getSchemaPath } from '@nestjs/swagger';
+import { ResponseDto } from '../src/global/dtos/response.dto';
+
+export interface ApiSuccessCreateOptions {
+  isArray: boolean;
+  status?: number;
+  exampleDesciption?: string;
+  model: Type<any>;
+  isNotValue?: boolean;
+}
+
+export function ApiSuccessResponse(options: ApiSuccessCreateOptions) {
+  const { isArray, status, exampleDesciption, model, isNotValue } = options;
+  const modelType = isArray ? 'array' : 'object';
+  let dataPropertySwaggerValue: any = {
+    type: 'array',
+    example: '[]',
+  };
+
+  if (!isNotValue) {
+    dataPropertySwaggerValue = isArray
+      ? {
+          type: modelType,
+          items: { $ref: getSchemaPath(model) },
+        }
+      : {
+          type: modelType,
+          $ref: getSchemaPath(model),
+        };
+  }
+
+  return applyDecorators(
+    ApiExtraModels(model),
+    ApiOkResponse({
+      schema: {
+        allOf: [
+          {
+            $ref: getSchemaPath(ResponseDto),
+          },
+          {
+            properties: {
+              status: {
+                type: 'number',
+                example: status ? status : 200,
+                description: 'HTTP STATUS 코드',
+              },
+              message: {
+                type: 'string',
+                example: exampleDesciption ? exampleDesciption : 'xx 조회 성공',
+                description: 'API 결과값에 대한 메시지',
+              },
+              data: dataPropertySwaggerValue,
+            },
+          },
+        ],
+      },
+    }),
+  );
+}

--- a/docs/auth/auth.swagger.ts
+++ b/docs/auth/auth.swagger.ts
@@ -3,13 +3,13 @@ import {
   ApiBadRequestResponse,
   ApiConflictResponse,
   ApiHeader,
-  ApiOkResponse,
   ApiOperation,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { RefreshResponseDto } from 'src/domain/auth/dtos/refresh-response.dto';
 import { ResponseDto } from 'src/global/dtos/response.dto';
+import { ApiSuccessResponse } from '../api.success.response';
 
 export function LogOutDocs() {
   return applyDecorators(
@@ -26,8 +26,12 @@ export function LogOutDocs() {
       summary: '로그아웃',
       description: '로그아웃 요청',
     }),
-    ApiOkResponse({
-      description: '로그아웃 성공',
+    ApiSuccessResponse({
+      isArray: true,
+      exampleDesciption: '로그아웃 성공',
+      status: 200,
+      model: Array,
+      isNotValue: true,
     }),
     ApiBadRequestResponse({
       description: 'header에 토큰이 없는 경우 or token 값 자체가 이상한 경우',
@@ -55,9 +59,12 @@ export function RefreshDocs() {
         example: 'Authorization Bearer ${Access 토큰}',
       },
     }),
-    ApiOkResponse({
-      description: 'access 토큰 재 발급 성공',
-      type: RefreshResponseDto,
+    ApiSuccessResponse({
+      isArray: false,
+      exampleDesciption: 'access 토큰 재 발급 성공',
+      status: 200,
+      model: RefreshResponseDto,
+      isNotValue: false,
     }),
     ApiOperation({
       summary: 'refresh 요청',

--- a/docs/auth/oauth.swagger.ts
+++ b/docs/auth/oauth.swagger.ts
@@ -2,7 +2,6 @@ import { applyDecorators } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
   ApiConflictResponse,
-  ApiCreatedResponse,
   ApiOperation,
   ApiResponse,
   ApiTags,
@@ -11,6 +10,7 @@ import {
 import { OAuthLoginResponseDto } from 'src/domain/auth/dtos/oauth-login.response.dto';
 import { OAuthSignUpResponseDto } from 'src/domain/auth/dtos/oauth-signup.response.dto';
 import { ResponseDto } from 'src/global/dtos/response.dto';
+import { ApiSuccessResponse } from '../api.success.response';
 
 export function OAuthKakaoLoginDocs() {
   return applyDecorators(
@@ -28,11 +28,10 @@ export function OAuthKakaoLoginDocs() {
         example: OAuthLoginResponseDto.newUser(),
       },
     }),
-    ApiResponse({
-      status: 201,
-      description:
-        '이미 로그인이 된 경우(status 200인데 문서 status 중복 표기 이슈로 201로 대체합니다) , is_new_user : false 값',
-      type: OAuthLoginResponseDto,
+    ApiSuccessResponse({
+      isArray: false,
+      exampleDesciption: '로그인 성공',
+      model: OAuthLoginResponseDto,
     }),
     ApiBadRequestResponse({
       description: 'token 값이 body에 없거나, 잘못된 토큰인 경우',
@@ -57,9 +56,11 @@ export function OAuthKakaoSignUpDocs() {
       description:
         '회원가입 프로세스는 idToken으로 검증하고, kakao access토큰으로 name,email을 받고 나머지 data는 body로 받습니다',
     }),
-    ApiCreatedResponse({
-      description: '회원가입 성공',
-      type: OAuthSignUpResponseDto,
+    ApiSuccessResponse({
+      isArray: false,
+      model: OAuthSignUpResponseDto,
+      exampleDesciption: '회원가입 성공',
+      status: 201,
     }),
     ApiBadRequestResponse({
       description: 'body의 값이 잘못됐거나 idToken,accessToken이 잘못된 경우',

--- a/docs/contents/contents.swagger.ts
+++ b/docs/contents/contents.swagger.ts
@@ -3,7 +3,6 @@ import {
   ApiBadRequestResponse,
   ApiHeader,
   ApiNotFoundResponse,
-  ApiOkResponse,
   ApiOperation,
   ApiParam,
   ApiQuery,
@@ -14,6 +13,7 @@ import { ContentsDetailResponseDto } from 'src/domain/contents/dtos/contents-det
 import { ContentsResponseDto } from 'src/domain/contents/dtos/contents-response.dto';
 import { ResponseDto } from 'src/global/dtos/response.dto';
 import { ContentsLikedResponseDto } from 'src/domain/contents/dtos/contents-liked-response.dto';
+import { ApiSuccessResponse } from '../api.success.response';
 
 export function GetContentsDocs() {
   return applyDecorators(
@@ -29,7 +29,11 @@ export function GetContentsDocs() {
       description: '카테고리명 (취미 / 진로 / 활동)',
       required: false,
     }),
-    ApiOkResponse({ type: [ContentsResponseDto] }),
+    ApiSuccessResponse({
+      model: ContentsResponseDto,
+      isArray: true,
+      exampleDesciption: '게시글 전체 조회 성공',
+    }),
   );
 }
 
@@ -44,7 +48,11 @@ export function GetContentDetailDocs() {
       type: 'number',
       description: '게시물 id',
     }),
-    ApiOkResponse({ type: ContentsDetailResponseDto }),
+    ApiSuccessResponse({
+      model: ContentsDetailResponseDto,
+      isArray: false,
+      exampleDesciption: '게시글 상세 조회 성공',
+    }),
   );
 }
 
@@ -64,7 +72,11 @@ export function SearchByKeywordDocs() {
       description:
         "keyword가 포함된 게시물이 없을 때: 'Not found contents including keyword: ' + ${keyword}'",
     }),
-    ApiOkResponse({ type: [ContentsResponseDto] }),
+    ApiSuccessResponse({
+      model: ContentsResponseDto,
+      isArray: true,
+      exampleDesciption: '게시글 검색 성공',
+    }),
   );
 }
 
@@ -94,7 +106,11 @@ export function LikeContentDocs() {
         example: ResponseDto.fail(400, 'token이 필요합니다.'),
       },
     }),
-    ApiOkResponse({ type: ContentsLikedResponseDto }),
+    ApiSuccessResponse({
+      model: ContentsLikedResponseDto,
+      isArray: false,
+      exampleDesciption: '게시글 좋아요 성공',
+    }),
   );
 }
 
@@ -126,7 +142,12 @@ export function UnLikeContentDocs() {
         example: ResponseDto.fail(400, 'token이 필요합니다.'),
       },
     }),
-    ApiOkResponse(),
+    ApiSuccessResponse({
+      model: Array,
+      isArray: true,
+      exampleDesciption: '게시글 좋아요 취소 성공',
+      isNotValue: true,
+    }),
   );
 }
 
@@ -168,6 +189,10 @@ export function GetLikedContentsDocs() {
       description:
         '좋아요를 누른 게시물이 없는 경우: 좋아요를 누른 (${contentsRequestDto.filter}) 게시물이 없습니다',
     }),
-    ApiOkResponse({ type: [ContentsLikedResponseDto] }),
+    ApiSuccessResponse({
+      model: ContentsLikedResponseDto,
+      isArray: true,
+      exampleDesciption: '좋아요한 게시글 조회 성공',
+    }),
   );
 }

--- a/docs/tag/tag.swagger.ts
+++ b/docs/tag/tag.swagger.ts
@@ -1,6 +1,7 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { TagResponseDto } from '../../src/domain/tags/dtos/tag.response.dto';
+import { ApiSuccessResponse } from '../api.success.response';
 
 export function GetAllTagDocs() {
   return applyDecorators(
@@ -9,9 +10,10 @@ export function GetAllTagDocs() {
       summary: '성향 태그 전체 조회',
       description: '회원가입 전 태그 데이터 전체 조회를 위한 API 입니다',
     }),
-    ApiOkResponse({
-      description: '태그 조회 성공',
-      type: TagResponseDto,
+    ApiSuccessResponse({
+      isArray: true,
+      exampleDesciption: '태그 조회 성공',
+      model: TagResponseDto,
     }),
   );
 }

--- a/docs/user/user.swagger.ts
+++ b/docs/user/user.swagger.ts
@@ -2,13 +2,13 @@ import { applyDecorators } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
   ApiHeader,
-  ApiOkResponse,
   ApiOperation,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { UserInfoResponseDto } from 'src/domain/user/dtos/user-info.response.dto';
 import { ResponseDto } from 'src/global/dtos/response.dto';
+import { ApiSuccessResponse } from '../api.success.response';
 
 export function GetUserInfoDocs() {
   return applyDecorators(
@@ -21,13 +21,16 @@ export function GetUserInfoDocs() {
         example: 'Authorization Bearer ${Access 토큰}',
       },
     }),
-    ApiOkResponse({
-      description: '유저 정보 조회 성공',
-      type: UserInfoResponseDto,
-    }),
+
     ApiOperation({
       summary: '유저 정보 조회',
       description: 'access 토큰으로 유저 정보를 조회합니다.',
+    }),
+    ApiSuccessResponse({
+      isArray: false,
+      model: UserInfoResponseDto,
+      status: 200,
+      exampleDesciption: '유저 조회 성공',
     }),
     ApiBadRequestResponse({
       description: 'header에 토큰이 없는 경우 or token 값 자체가 이상한 경우',

--- a/src/domain/tags/controller/tag.controller.ts
+++ b/src/domain/tags/controller/tag.controller.ts
@@ -10,7 +10,7 @@ export class TagController {
   @Get('')
   @GetAllTagDocs()
   public async getTagAll() {
-    const reuslt = await this.tagService.getTags();
-    return ResponseDto.okWithData(HttpStatus.OK, '태그 조회 성공', reuslt);
+    const result = await this.tagService.getTags();
+    return ResponseDto.okWithData(HttpStatus.OK, '태그 조회 성공', result);
   }
 }

--- a/src/domain/tags/controller/tag.controller.ts
+++ b/src/domain/tags/controller/tag.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, HttpStatus } from '@nestjs/common';
 import { TagService } from '../service/tag.service';
 import { GetAllTagDocs } from '../../../../docs/tag/tag.swagger';
+import { ResponseDto } from '../../../global/dtos/response.dto';
 
 @Controller('/api/tag')
 export class TagController {
@@ -9,6 +10,7 @@ export class TagController {
   @Get('')
   @GetAllTagDocs()
   public async getTagAll() {
-    return await this.tagService.getTags();
+    const reuslt = await this.tagService.getTags();
+    return ResponseDto.okWithData(HttpStatus.OK, '태그 조회 성공', reuslt);
   }
 }


### PR DESCRIPTION
### 관련 이슈가 있다면 적어주세요.

## 📌 개발 이유
- Tag API에서 Global ResponseDTO를 넣지 않아서 추가했습니다.

- Swagger ApiSuccessResponse 라는 커스텀 어노테이션을 만들었습니다.

1. 공통 응답 DTO + 배열인 경우
(List 조회, 검색 API)
<img src="https://github.com/Keyneez/Keyneez-Server-Release/assets/28949213/a1dab030-19ba-4cd5-85d6-16218815b009" width=500px>

2. 공통응답 DTO + 객체인 경우
(단일 조회 / 회원가입 로직)
<img src="https://github.com/Keyneez/Keyneez-Server-Release/assets/28949213/fcc803ee-0855-4745-9e6b-37d50021e397" width=500px>

3. 빈 값인 경우
(로그아웃, 좋아요 취소)
<img src="https://github.com/Keyneez/Keyneez-Server-Release/assets/28949213/35bd8729-c70d-4731-9111-b125cbb6f790" width=500px>

- 급하게 짜느라 ApiSuccessResponse 코드가 너무 더럽네요.. 이부분은 차후 리팩토링 사항에 두겠습니다.
- 좋은 레퍼런스를 발견했네요 https://devnm.tistory.com/22

- 현재 로그인 요청시 회원가입이 필요한 유저랑 필요하지 않은 유저의 같은 status 코드에 다른 응답을 swagger로 처리하고 싶은데 이 부분이 주요 리팩토링 예정 사항입니다.

## 💻 수정 사항

## 🧪 테스트 방법

## ⛳️ 고민한 점 || 궁굼한 점

## 🎯 리뷰 포인트

## 📁 레퍼런스

Closes #18 