### PR TITLE
fix : content detail res dto & swagger

### DIFF
--- a/docs/contents/contents.swagger.ts
+++ b/docs/contents/contents.swagger.ts
@@ -23,6 +23,26 @@ export function GetContentsDocs() {
       description:
         'Query가 들어오지 않을 시 전체를 조회하며, filter 이름의 쿼리 스트링이 들어올 시 카테고리가 일치하는 게시물만 조회됩니다',
     }),
+    ApiHeader({
+      name: 'Authorization',
+      description:
+        "access token이 필요합니다 key : Authorization, value : 'Bearer ${Token}'",
+      schema: {
+        example: 'Authorization Bearer ${Access 토큰}',
+      },
+    }),
+    ApiUnauthorizedResponse({
+      description: 'access 토큰이 만료된 경우',
+      schema: {
+        example: ResponseDto.fail(401, '만료된 token.'),
+      },
+    }),
+    ApiBadRequestResponse({
+      description: 'header에 토큰이 없는 경우 or token 값 자체가 이상한 경우',
+      schema: {
+        example: ResponseDto.fail(400, 'token이 필요합니다.'),
+      },
+    }),
     ApiQuery({
       name: 'filter',
       type: 'string',
@@ -43,10 +63,30 @@ export function GetContentDetailDocs() {
     ApiOperation({
       summary: '게시물 상세조회 API 입니다.',
     }),
+    ApiHeader({
+      name: 'Authorization',
+      description:
+        "access token이 필요합니다 key : Authorization, value : 'Bearer ${Token}'",
+      schema: {
+        example: 'Authorization Bearer ${Access 토큰}',
+      },
+    }),
+    ApiUnauthorizedResponse({
+      description: 'access 토큰이 만료된 경우',
+      schema: {
+        example: ResponseDto.fail(401, '만료된 token.'),
+      },
+    }),
+    ApiBadRequestResponse({
+      description: 'header에 토큰이 없는 경우 or token 값 자체가 이상한 경우',
+      schema: {
+        example: ResponseDto.fail(400, 'token이 필요합니다.'),
+      },
+    }),
     ApiParam({
-      name: 'id',
+      name: 'pk',
       type: 'number',
-      description: '게시물 id',
+      description: '게시물 pk',
     }),
     ApiSuccessResponse({
       model: ContentsDetailResponseDto,
@@ -61,6 +101,26 @@ export function SearchByKeywordDocs() {
     ApiTags('Contents'),
     ApiOperation({
       summary: '게시물 검색 API 입니다',
+    }),
+    ApiHeader({
+      name: 'Authorization',
+      description:
+        "access token이 필요합니다 key : Authorization, value : 'Bearer ${Token}'",
+      schema: {
+        example: 'Authorization Bearer ${Access 토큰}',
+      },
+    }),
+    ApiUnauthorizedResponse({
+      description: 'access 토큰이 만료된 경우',
+      schema: {
+        example: ResponseDto.fail(401, '만료된 token.'),
+      },
+    }),
+    ApiBadRequestResponse({
+      description: 'header에 토큰이 없는 경우 or token 값 자체가 이상한 경우',
+      schema: {
+        example: ResponseDto.fail(400, 'token이 필요합니다.'),
+      },
     }),
     ApiQuery({
       name: 'keyword',
@@ -106,6 +166,11 @@ export function LikeContentDocs() {
         example: ResponseDto.fail(400, 'token이 필요합니다.'),
       },
     }),
+    ApiParam({
+      name: 'pk',
+      type: 'number',
+      description: '게시물 pk',
+    }),
     ApiSuccessResponse({
       model: ContentsLikedResponseDto,
       isArray: false,
@@ -145,6 +210,11 @@ export function UnLikeContentDocs() {
     ApiBadRequestResponse({
       description:
         'parameter에 number가 아닌 값이 포함된 경우 ex) 1,2,hi,3 : `Invalid parameter : ${pk}`',
+    }),
+    ApiParam({
+      name: 'pk',
+      type: 'number[]',
+      description: '게시물 pk 리스트 or 게시물 pk : ex. 1,2,3 or 4',
     }),
     ApiSuccessResponse({
       model: Array,

--- a/src/domain/contents/dtos/contents-detail-response.dto.ts
+++ b/src/domain/contents/dtos/contents-detail-response.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber } from 'class-validator';
+import { Like } from './contents-response.dto';
 
 export class ContentsDetailResponseDto {
   @ApiProperty({
@@ -107,4 +108,11 @@ export class ContentsDetailResponseDto {
     description: '수정 일자',
   })
   readonly updated_at: Date;
+
+  @ApiProperty({
+    type: [Like],
+    nullable: false,
+    description: '좋아요 정보(없을 경우 빈 리스트)',
+  })
+  readonly Likes: Like[];
 }


### PR DESCRIPTION
### 관련 이슈가 있다면 적어주세요.

## 📌 개발 이유
게시물 상세 조회 시 DTO 수정이 이루어지지 않아 swagger에 반영되지 않는 이슈가 발생하였습니다

## 💻 수정 사항
게시물 상세 조회 시 return 되는 dto에 Likes 를 추가하고, 
contents 관련 swagger을 전체 검토하며 header 선언이 빠진 부분과 parameter 값에 대한 명세가 없는 경우 이를 추가하였습니다

## 🧪 테스트 방법

## ⛳️ 고민한 점 || 궁굼한 점

## 🎯 리뷰 포인트

## 📁 레퍼런스
