### PR TITLE
Feat/contents

### DIFF
--- a/docs/contents/contents.swagger.ts
+++ b/docs/contents/contents.swagger.ts
@@ -11,7 +11,7 @@ import { ContentsDetailResponseDto } from 'src/domain/contents/dtos/contents-det
 import { ContentsResponseDto } from 'src/domain/contents/dtos/contents-response.dto';
 import { ContentsLikedResponseDto } from 'src/domain/contents/dtos/contents-liked-response.dto';
 import { ApiSuccessResponse } from '../api.success.response';
-import { RequireAccessToken } from 'docs/require.access-token';
+import { RequireAccessToken } from '../require.access-token';
 
 export function GetContentsDocs() {
   return applyDecorators(

--- a/docs/contents/contents.swagger.ts
+++ b/docs/contents/contents.swagger.ts
@@ -1,19 +1,17 @@
 import { applyDecorators } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
-  ApiHeader,
   ApiNotFoundResponse,
   ApiOperation,
   ApiParam,
   ApiQuery,
   ApiTags,
-  ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { ContentsDetailResponseDto } from 'src/domain/contents/dtos/contents-detail-response.dto';
 import { ContentsResponseDto } from 'src/domain/contents/dtos/contents-response.dto';
-import { ResponseDto } from 'src/global/dtos/response.dto';
 import { ContentsLikedResponseDto } from 'src/domain/contents/dtos/contents-liked-response.dto';
 import { ApiSuccessResponse } from '../api.success.response';
+import { RequireAccessToken } from 'docs/require.access-token';
 
 export function GetContentsDocs() {
   return applyDecorators(
@@ -23,26 +21,7 @@ export function GetContentsDocs() {
       description:
         'Query가 들어오지 않을 시 전체를 조회하며, filter 이름의 쿼리 스트링이 들어올 시 카테고리가 일치하는 게시물만 조회됩니다',
     }),
-    ApiHeader({
-      name: 'Authorization',
-      description:
-        "access token이 필요합니다 key : Authorization, value : 'Bearer ${Token}'",
-      schema: {
-        example: 'Authorization Bearer ${Access 토큰}',
-      },
-    }),
-    ApiUnauthorizedResponse({
-      description: 'access 토큰이 만료된 경우',
-      schema: {
-        example: ResponseDto.fail(401, '만료된 token.'),
-      },
-    }),
-    ApiBadRequestResponse({
-      description: 'header에 토큰이 없는 경우 or token 값 자체가 이상한 경우',
-      schema: {
-        example: ResponseDto.fail(400, 'token이 필요합니다.'),
-      },
-    }),
+    RequireAccessToken(),
     ApiQuery({
       name: 'filter',
       type: 'string',
@@ -63,26 +42,7 @@ export function GetContentDetailDocs() {
     ApiOperation({
       summary: '게시물 상세조회 API 입니다.',
     }),
-    ApiHeader({
-      name: 'Authorization',
-      description:
-        "access token이 필요합니다 key : Authorization, value : 'Bearer ${Token}'",
-      schema: {
-        example: 'Authorization Bearer ${Access 토큰}',
-      },
-    }),
-    ApiUnauthorizedResponse({
-      description: 'access 토큰이 만료된 경우',
-      schema: {
-        example: ResponseDto.fail(401, '만료된 token.'),
-      },
-    }),
-    ApiBadRequestResponse({
-      description: 'header에 토큰이 없는 경우 or token 값 자체가 이상한 경우',
-      schema: {
-        example: ResponseDto.fail(400, 'token이 필요합니다.'),
-      },
-    }),
+    RequireAccessToken(),
     ApiParam({
       name: 'pk',
       type: 'number',
@@ -102,26 +62,7 @@ export function SearchByKeywordDocs() {
     ApiOperation({
       summary: '게시물 검색 API 입니다',
     }),
-    ApiHeader({
-      name: 'Authorization',
-      description:
-        "access token이 필요합니다 key : Authorization, value : 'Bearer ${Token}'",
-      schema: {
-        example: 'Authorization Bearer ${Access 토큰}',
-      },
-    }),
-    ApiUnauthorizedResponse({
-      description: 'access 토큰이 만료된 경우',
-      schema: {
-        example: ResponseDto.fail(401, '만료된 token.'),
-      },
-    }),
-    ApiBadRequestResponse({
-      description: 'header에 토큰이 없는 경우 or token 값 자체가 이상한 경우',
-      schema: {
-        example: ResponseDto.fail(400, 'token이 필요합니다.'),
-      },
-    }),
+    RequireAccessToken(),
     ApiQuery({
       name: 'keyword',
       type: 'string',
@@ -140,72 +81,13 @@ export function SearchByKeywordDocs() {
   );
 }
 
-export function RecommendContentsDocs() {
-  return applyDecorators(
-    ApiTags('Contents'),
-    ApiOperation({
-      summary: '추천 게시물 조회 API 입니다',
-    }),
-    ApiHeader({
-      name: 'Authorization',
-      description:
-        "access token이 필요합니다 key : Authorization, value : 'Bearer ${Token}'",
-      schema: {
-        example: 'Authorization Bearer ${Access 토큰}',
-      },
-    }),
-    ApiUnauthorizedResponse({
-      description: 'access 토큰이 만료된 경우',
-      schema: {
-        example: ResponseDto.fail(401, '만료된 token.'),
-      },
-    }),
-    ApiBadRequestResponse({
-      description: 'header에 토큰이 없는 경우 or token 값 자체가 이상한 경우',
-      schema: {
-        example: ResponseDto.fail(400, 'token이 필요합니다.'),
-      },
-    }),
-    ApiQuery({
-      name: 'keyword',
-      type: 'string',
-      description: '검색 키워드',
-      required: true,
-    }),
-    ApiSuccessResponse({
-      model: ContentsResponseDto,
-      isArray: true,
-      exampleDesciption: '추천 게시물 조회 성공',
-    }),
-  );
-}
-
 export function LikeContentDocs() {
   return applyDecorators(
     ApiTags('ContentLike'),
     ApiOperation({
       summary: '게시물 좋아요',
     }),
-    ApiHeader({
-      name: 'Authorization',
-      description:
-        "access token이 필요합니다 key : Authorization, value : 'Bearer ${Token}'",
-      schema: {
-        example: 'Authorization Bearer ${Access 토큰}',
-      },
-    }),
-    ApiUnauthorizedResponse({
-      description: 'access 토큰이 만료된 경우',
-      schema: {
-        example: ResponseDto.fail(401, '만료된 token.'),
-      },
-    }),
-    ApiBadRequestResponse({
-      description: 'header에 토큰이 없는 경우 or token 값 자체가 이상한 경우',
-      schema: {
-        example: ResponseDto.fail(400, 'token이 필요합니다.'),
-      },
-    }),
+    RequireAccessToken(),
     ApiParam({
       name: 'pk',
       type: 'number',
@@ -227,26 +109,7 @@ export function UnLikeContentDocs() {
       description:
         '여러 개의 게시물을 좋아요 취소할 때에는 parameter에 여러 pk를 ,로 분리하여 입력하시면 됩니다',
     }),
-    ApiHeader({
-      name: 'Authorization',
-      description:
-        "access token이 필요합니다 key : Authorization, value : 'Bearer ${Token}'",
-      schema: {
-        example: 'Authorization Bearer ${Access 토큰}',
-      },
-    }),
-    ApiUnauthorizedResponse({
-      description: 'access 토큰이 만료된 경우',
-      schema: {
-        example: ResponseDto.fail(401, '만료된 token.'),
-      },
-    }),
-    ApiBadRequestResponse({
-      description: 'header에 토큰이 없는 경우 or token 값 자체가 이상한 경우',
-      schema: {
-        example: ResponseDto.fail(400, 'token이 필요합니다.'),
-      },
-    }),
+    RequireAccessToken(),
     ApiBadRequestResponse({
       description:
         'parameter에 number가 아닌 값이 포함된 경우 ex) 1,2,hi,3 : `Invalid parameter : ${pk}`',
@@ -273,31 +136,12 @@ export function GetLikedContentsDocs() {
       description:
         'Query가 들어오지 않을 시 전체를 조회하며, filter 이름의 쿼리 스트링이 들어올 시 카테고리가 일치하는 게시물만 조회됩니다',
     }),
-    ApiHeader({
-      name: 'Authorization',
-      description:
-        "access token이 필요합니다 key : Authorization, value : 'Bearer ${Token}'",
-      schema: {
-        example: 'Authorization Bearer ${Access 토큰}',
-      },
-    }),
+    RequireAccessToken(),
     ApiQuery({
       name: 'filter',
       type: 'string',
       description: '카테고리명 (취미 / 진로 / 활동)',
       required: false,
-    }),
-    ApiUnauthorizedResponse({
-      description: 'access 토큰이 만료된 경우',
-      schema: {
-        example: ResponseDto.fail(401, '만료된 token.'),
-      },
-    }),
-    ApiBadRequestResponse({
-      description: 'header에 토큰이 없는 경우 or token 값 자체가 이상한 경우',
-      schema: {
-        example: ResponseDto.fail(400, 'token이 필요합니다.'),
-      },
     }),
     ApiNotFoundResponse({
       description:
@@ -307,6 +151,27 @@ export function GetLikedContentsDocs() {
       model: ContentsLikedResponseDto,
       isArray: true,
       exampleDesciption: '좋아요한 게시글 조회 성공',
+    }),
+  );
+}
+
+export function RecommendContentsDocs() {
+  return applyDecorators(
+    ApiTags('Contents'),
+    ApiOperation({
+      summary: '추천 게시물 조회 API 입니다',
+    }),
+    RequireAccessToken(),
+    ApiQuery({
+      name: 'keyword',
+      type: 'string',
+      description: '검색 키워드',
+      required: true,
+    }),
+    ApiSuccessResponse({
+      model: ContentsResponseDto,
+      isArray: true,
+      exampleDesciption: '추천 게시물 조회 성공',
     }),
   );
 }

--- a/docs/contents/contents.swagger.ts
+++ b/docs/contents/contents.swagger.ts
@@ -140,6 +140,46 @@ export function SearchByKeywordDocs() {
   );
 }
 
+export function RecommendContentsDocs() {
+  return applyDecorators(
+    ApiTags('Contents'),
+    ApiOperation({
+      summary: '추천 게시물 조회 API 입니다',
+    }),
+    ApiHeader({
+      name: 'Authorization',
+      description:
+        "access token이 필요합니다 key : Authorization, value : 'Bearer ${Token}'",
+      schema: {
+        example: 'Authorization Bearer ${Access 토큰}',
+      },
+    }),
+    ApiUnauthorizedResponse({
+      description: 'access 토큰이 만료된 경우',
+      schema: {
+        example: ResponseDto.fail(401, '만료된 token.'),
+      },
+    }),
+    ApiBadRequestResponse({
+      description: 'header에 토큰이 없는 경우 or token 값 자체가 이상한 경우',
+      schema: {
+        example: ResponseDto.fail(400, 'token이 필요합니다.'),
+      },
+    }),
+    ApiQuery({
+      name: 'keyword',
+      type: 'string',
+      description: '검색 키워드',
+      required: true,
+    }),
+    ApiSuccessResponse({
+      model: ContentsResponseDto,
+      isArray: true,
+      exampleDesciption: '추천 게시물 조회 성공',
+    }),
+  );
+}
+
 export function LikeContentDocs() {
   return applyDecorators(
     ApiTags('ContentLike'),

--- a/docs/require.access-token.ts
+++ b/docs/require.access-token.ts
@@ -1,0 +1,33 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiHeader,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { ResponseDto } from '../src/global/dtos/response.dto';
+
+export function RequireAccessToken() {
+  return applyDecorators(
+    ApiHeader({
+      name: 'Authorization',
+      description:
+        "access token이 필요합니다 key : Authorization, value : 'Bearer ${Token}'",
+      schema: {
+        example: 'Authorization Bearer ${Access 토큰}',
+      },
+    }),
+    ApiBadRequestResponse({
+      description:
+        'header에 토큰이 없는 경우 or token 값 자체가 이상한 경우, request body를 같이 보내는 경우 body 값 검증도 포함',
+      schema: {
+        example: ResponseDto.fail(400, 'token이 필요합니다.'),
+      },
+    }),
+    ApiUnauthorizedResponse({
+      description: 'access 토큰이 만료된 경우',
+      schema: {
+        example: ResponseDto.fail(401, '만료된 token.'),
+      },
+    }),
+  );
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,9 +38,9 @@ model Contents {
   created_at        DateTime          @default(now())
   updated_at        DateTime          @updatedAt
   category          String            @db.VarChar(30)
-  tag               String            @db.VarChar(30)
+  tag               String?           @db.VarChar(30)
   ContentCategories ContentCategories @relation(fields: [category], references: [category], onDelete: Cascade, map: "category_fk")
-  Tags              Tags              @relation(fields: [tag], references: [tag], onDelete: Cascade, map: "tag_fk")
+  Tags              Tags?             @relation(fields: [tag], references: [tag], onDelete: Cascade, map: "tag_fk")
   Likes             Likes[]
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,24 +24,32 @@ model Tags {
 }
 
 model Contents {
-  content_pk        Int               @id @unique @default(autoincrement())
-  title             String            @db.VarChar(30)
-  link              String            @db.VarChar(100)
-  img               String            @db.VarChar(100)
-  place             String            @db.VarChar(30)
-  introduction      String            @db.VarChar(200)
-  start_at          String?           @db.VarChar(10)
-  end_at            String?           @db.VarChar(10)
+  content_pk        Int                 @id @unique @default(autoincrement())
+  title             String              @db.VarChar(30)
+  link              String              @db.VarChar(100)
+  img               String              @db.VarChar(100)
+  place             String              @db.VarChar(30)
+  introduction      String              @db.VarChar(200)
+  start_at          String?             @db.VarChar(10)
+  end_at            String?             @db.VarChar(10)
   inquiry           String[]
   price             String[]
   benefit           String[]
-  created_at        DateTime          @default(now())
-  updated_at        DateTime          @updatedAt
-  category          String            @db.VarChar(30)
-  tag               String?           @db.VarChar(30)
-  ContentCategories ContentCategories @relation(fields: [category], references: [category], onDelete: Cascade, map: "category_fk")
-  Tags              Tags?             @relation(fields: [tag], references: [tag], onDelete: Cascade, map: "tag_fk")
+  created_at        DateTime            @default(now())
+  updated_at        DateTime            @updatedAt
+  category          String              @db.VarChar(30)
+  tag               String?             @db.VarChar(30)
+  ContentCategories ContentCategories   @relation(fields: [category], references: [category], onDelete: Cascade, map: "category_fk")
+  Tags              Tags?               @relation(fields: [tag], references: [tag], onDelete: Cascade, map: "tag_fk")
   Likes             Likes[]
+  RecommendContents RecommendContents[]
+}
+
+model RecommendContents {
+  recomment_pk Int      @id @unique @default(autoincrement())
+  content      Int
+  created_at   DateTime @default(now())
+  Contents     Contents @relation(fields: [content], references: [content_pk], onDelete: Cascade, map: "content_fk")
 }
 
 model Likes {

--- a/src/domain/auth/dtos/oauth-signup.request.dto.ts
+++ b/src/domain/auth/dtos/oauth-signup.request.dto.ts
@@ -88,6 +88,6 @@ export class OAuthSignUpRequestDto {
   })
   @IsNumber({}, { each: true })
   @ArrayMaxSize(3)
-  @ArrayMinSize(3)
+  @ArrayMinSize(1)
   tag_pks: number[];
 }

--- a/src/domain/contents/controller/contents.controller.ts
+++ b/src/domain/contents/controller/contents.controller.ts
@@ -41,7 +41,7 @@ export class ContentsController {
       user.userPk,
       contentsRequestDto,
     );
-    return ResponseDto.okWithData(HttpStatus.OK, '콘텐츠 조회 성공', result);
+    return ResponseDto.okWithData(HttpStatus.OK, '게시물 조회 성공', result);
   }
 
   @Get('/search')
@@ -55,7 +55,7 @@ export class ContentsController {
       user.userPk,
       keyword,
     );
-    return ResponseDto.okWithData(HttpStatus.OK, '콘텐츠 검색 성공', result);
+    return ResponseDto.okWithData(HttpStatus.OK, '게시물 검색 성공', result);
   }
 
   @Get('/liked')
@@ -71,9 +71,15 @@ export class ContentsController {
     );
     return ResponseDto.okWithData(
       HttpStatus.OK,
-      '좋아요 콘텐츠 조회 성공',
+      '좋아요 게시물 조회 성공',
       result,
     );
+  }
+
+  @Get('/recommend')
+  @UseGuards(AccessTokenGuard)
+  async recommend(@User() user: JwtAuthUser) {
+    const result = await this.contentsService.recommendContents(user.userPk);
   }
 
   @Get('/:pk')

--- a/src/domain/contents/controller/contents.controller.ts
+++ b/src/domain/contents/controller/contents.controller.ts
@@ -17,6 +17,7 @@ import {
   GetContentsDocs,
   GetLikedContentsDocs,
   LikeContentDocs,
+  RecommendContentsDocs,
   SearchByKeywordDocs,
   UnLikeContentDocs,
 } from 'docs/contents/contents.swagger';
@@ -78,7 +79,10 @@ export class ContentsController {
 
   @Get('/recommend')
   @UseGuards(AccessTokenGuard)
-  async recommend(@User() user: JwtAuthUser) {
+  @RecommendContentsDocs()
+  async recommend(
+    @User() user: JwtAuthUser,
+  ): Promise<ResponseDto<ContentsResponseDto[]>> {
     const result = await this.contentsService.recommendContents(user.userPk);
     return ResponseDto.okWithData(
       HttpStatus.OK,

--- a/src/domain/contents/controller/contents.controller.ts
+++ b/src/domain/contents/controller/contents.controller.ts
@@ -80,6 +80,11 @@ export class ContentsController {
   @UseGuards(AccessTokenGuard)
   async recommend(@User() user: JwtAuthUser) {
     const result = await this.contentsService.recommendContents(user.userPk);
+    return ResponseDto.okWithData(
+      HttpStatus.OK,
+      '추천 게시물 조회 성공',
+      result,
+    );
   }
 
   @Get('/:pk')

--- a/src/domain/contents/dtos/contents-detail-response.dto.ts
+++ b/src/domain/contents/dtos/contents-detail-response.dto.ts
@@ -27,7 +27,7 @@ export class ContentsDetailResponseDto {
 
   @ApiProperty({
     type: String,
-    nullable: false,
+    nullable: true,
     description: '게시물 태그',
   })
   readonly tag: string;

--- a/src/domain/contents/repository/contents.repository.ts
+++ b/src/domain/contents/repository/contents.repository.ts
@@ -270,7 +270,7 @@ export class ContentsRepository {
           orderBy: {
             created_at: 'desc',
           },
-          take: 5,
+          take: 3,
         });
         const result = content.map((contents) => contents.Contents);
         return result;

--- a/src/domain/contents/repository/contents.repository.ts
+++ b/src/domain/contents/repository/contents.repository.ts
@@ -11,14 +11,22 @@ import { ContentsLikedResponseDto } from '../dtos/contents-liked-response.dto';
 export class ContentsRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async findCategoryPk(filter: string): Promise<ContentCategories> {
-    const category = await this.prisma.contentCategories.findUnique({
-      where: {
-        category: filter,
-      },
-    });
+  async findCategoryName(pks: number[]) {
+    const categories = Promise.all(
+      pks.map(async (pk) => {
+        const category = await this.prisma.contentCategories.findUnique({
+          where: {
+            category_pk: pk,
+          },
+          select: {
+            category: true,
+          },
+        });
+        return category.category;
+      }),
+    );
 
-    return category;
+    return categories;
   }
 
   async getFilteredContents(
@@ -217,4 +225,25 @@ export class ContentsRepository {
 
     return result;
   }
+
+  async getUserTags(user: number) {
+    const tags = await this.prisma.userTags.findMany({
+      where: {
+        user_fk: user,
+      },
+      include: {
+        Tags: {
+          select: {
+            category_fk: true,
+          },
+        },
+      },
+    });
+
+    const result = tags.map((tag) => tag.Tags.category_fk);
+
+    return result;
+  }
+
+  async recommendContents(categories: {}) {}
 }

--- a/src/domain/contents/repository/contents.repository.ts
+++ b/src/domain/contents/repository/contents.repository.ts
@@ -11,24 +11,6 @@ import { ContentsLikedResponseDto } from '../dtos/contents-liked-response.dto';
 export class ContentsRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async findCategoryName(pks: number[]) {
-    const categories = Promise.all(
-      pks.map(async (pk) => {
-        const category = await this.prisma.contentCategories.findUnique({
-          where: {
-            category_pk: pk,
-          },
-          select: {
-            category: true,
-          },
-        });
-        return category.category;
-      }),
-    );
-
-    return categories;
-  }
-
   async getFilteredContents(
     user: number,
     filter: CategoryFilter,
@@ -234,13 +216,17 @@ export class ContentsRepository {
       include: {
         Tags: {
           select: {
-            category_fk: true,
+            ContentCategories: {
+              select: {
+                category: true,
+              },
+            },
           },
         },
       },
     });
 
-    const result = tags.map((tag) => tag.Tags.category_fk);
+    const result = tags.map((tag) => tag.Tags.ContentCategories.category);
 
     return result;
   }

--- a/src/domain/contents/repository/contents.repository.ts
+++ b/src/domain/contents/repository/contents.repository.ts
@@ -245,5 +245,44 @@ export class ContentsRepository {
     return result;
   }
 
-  async recommendContents(categories: {}) {}
+  async recommendContents(categories: {}) {
+    const filters = Object.keys(categories);
+    const contents = Promise.all(
+      filters.map(async (filter) => {
+        const content = await this.prisma.recommendContents.findMany({
+          where: {
+            Contents: {
+              category: filter,
+            },
+          },
+          select: {
+            Contents: {
+              select: {
+                content_pk: true,
+                title: true,
+                category: true,
+                img: true,
+                start_at: true,
+                end_at: true,
+              },
+            },
+          },
+          orderBy: {
+            created_at: 'desc',
+          },
+          take: 5,
+        });
+        const result = content.map((contents) => contents.Contents);
+        return result;
+      }),
+    );
+
+    const randomContents = (await contents).map((content) => {
+      const shuffle = content.sort(() => 0.5 - Math.random());
+      const random = shuffle.slice(0, categories[content[0].category]);
+      return random;
+    });
+
+    return randomContents;
+  }
 }

--- a/src/domain/contents/service/contents.service.ts
+++ b/src/domain/contents/service/contents.service.ts
@@ -70,14 +70,16 @@ export class ContentsService {
     return contents;
   }
 
-  async recommendContents(user: number) {
+  async recommendContents(user: number): Promise<ContentsResponseDto[]> {
     const categories = await this.contentsRepository.getUserTags(user);
+    //* 카테고리 이름 받아오기
     const categoryNames = await this.contentsRepository.findCategoryName(
       categories,
     );
 
     const category = {};
 
+    //* 각 카테고리의 개수를 세어 객체 형태로 저장
     categoryNames.forEach((categoryName) => {
       if (category[categoryName]) {
         category[categoryName] += 1;
@@ -86,8 +88,10 @@ export class ContentsService {
       }
     });
 
+    //* 카테고리의 종류 개수
     const categoryCnt = Object.keys(category).length;
 
+    //* 기획 알고리즘에 맞추어 category 객체를 '카테고리':가져와야할 게시물의 수 로 조정
     if (categoryCnt == 1) {
       category[Object.keys(category)[0]] = 3;
     } else if (categoryCnt == 2) {
@@ -98,10 +102,12 @@ export class ContentsService {
       }
     }
 
+    //* 가져와야할 게시물의 개수대로 랜덤하게 (카테고리별 최근 3개의 게시물 중에) 가져오기
     const contents = await this.contentsRepository.recommendContents(category);
 
     const result = [];
 
+    //* 이중 리스트 구조 -> 단일 리스트로 변환
     for (const sublist of contents) {
       for (const obj of sublist) {
         result.push(obj);

--- a/src/domain/contents/service/contents.service.ts
+++ b/src/domain/contents/service/contents.service.ts
@@ -93,7 +93,7 @@ export class ContentsService {
     } else if (categoryCnt == 2) {
       const values = Object.values(category);
       if (values[0] == values[1]) {
-        const randomIdx = parseInt((Math.random() > 0.5).toString());
+        const randomIdx = Math.random() < 0.5 ? 0 : 1;
         category[Object.keys(category)[randomIdx]] = 2;
       }
     }

--- a/src/domain/contents/service/contents.service.ts
+++ b/src/domain/contents/service/contents.service.ts
@@ -86,8 +86,21 @@ export class ContentsService {
       }
     });
 
+    const categoryCnt = Object.keys(category).length;
+
+    if (categoryCnt == 1) {
+      category[Object.keys(category)[0]] = 3;
+    } else if (categoryCnt == 2) {
+      const values = Object.values(category);
+      if (values[0] == values[1]) {
+        const randomIdx = parseInt((Math.random() > 0.5).toString());
+        category[Object.keys(category)[randomIdx]] = 2;
+      }
+    }
+
     const contents = await this.contentsRepository.recommendContents(category);
-    // return contents;
+
+    return contents;
   }
 
   async getContentDetail(

--- a/src/domain/contents/service/contents.service.ts
+++ b/src/domain/contents/service/contents.service.ts
@@ -70,9 +70,7 @@ export class ContentsService {
     return contents;
   }
 
-  async recommendContents(user: number): Promise<ContentsResponseDto[]> {
-    const categoryNames = await this.contentsRepository.getUserTags(user);
-
+  private categoryCount(categoryNames: string[]) {
     const category = {};
 
     //* 각 카테고리의 개수를 세어 객체 형태로 저장
@@ -97,6 +95,13 @@ export class ContentsService {
         category[Object.keys(category)[randomIdx]] = 2;
       }
     }
+
+    return category;
+  }
+
+  async recommendContents(user: number): Promise<ContentsResponseDto[]> {
+    const categoryNames = await this.contentsRepository.getUserTags(user);
+    const category = this.categoryCount(categoryNames);
 
     //* 가져와야할 게시물의 개수대로 랜덤하게 (카테고리별 최근 3개의 게시물 중에) 가져오기
     const contents = await this.contentsRepository.recommendContents(category);

--- a/src/domain/contents/service/contents.service.ts
+++ b/src/domain/contents/service/contents.service.ts
@@ -71,11 +71,7 @@ export class ContentsService {
   }
 
   async recommendContents(user: number): Promise<ContentsResponseDto[]> {
-    const categories = await this.contentsRepository.getUserTags(user);
-    //* 카테고리 이름 받아오기
-    const categoryNames = await this.contentsRepository.findCategoryName(
-      categories,
-    );
+    const categoryNames = await this.contentsRepository.getUserTags(user);
 
     const category = {};
 

--- a/src/domain/contents/service/contents.service.ts
+++ b/src/domain/contents/service/contents.service.ts
@@ -70,6 +70,26 @@ export class ContentsService {
     return contents;
   }
 
+  async recommendContents(user: number) {
+    const categories = await this.contentsRepository.getUserTags(user);
+    const categoryNames = await this.contentsRepository.findCategoryName(
+      categories,
+    );
+
+    const category = {};
+
+    categoryNames.forEach((categoryName) => {
+      if (category[categoryName]) {
+        category[categoryName] += 1;
+      } else {
+        category[categoryName] = 1;
+      }
+    });
+
+    const contents = await this.contentsRepository.recommendContents(category);
+    // return contents;
+  }
+
   async getContentDetail(
     user: number,
     pk: number,

--- a/src/domain/contents/service/contents.service.ts
+++ b/src/domain/contents/service/contents.service.ts
@@ -100,7 +100,15 @@ export class ContentsService {
 
     const contents = await this.contentsRepository.recommendContents(category);
 
-    return contents;
+    const result = [];
+
+    for (const sublist of contents) {
+      for (const obj of sublist) {
+        result.push(obj);
+      }
+    }
+
+    return result;
   }
 
   async getContentDetail(


### PR DESCRIPTION
### 관련 이슈가 있다면 적어주세요.

## 📌 개발 이유
추천 게시물 조회 API를 개발하였습니다

## 💻 수정 사항
tag 받아오는 min length 1로 변경
디스코드의 대화 내용을 참고하여 contents 테이블의 tag를 nullable 하게 수정하였습니다

/recommend API 추가

1. 유저가 선택한 태그가 속한 카테고리 이름을 받아옵니다
2. 각 카테고리의 개수를 세어 객체 형태로 저장합니다 ex. {'활동': 2, '진로': 1}
3. 몇 종류의 카테고리가 나왔는 지 파악 후, 기획된 알고리즘에 맞추어 위에서 만든 객체의 value를, 가져와야할 게시물 수로 수정합니다
4. 각 카테고리별로, 최근에 업로드 된 3개의 게시물 중 가져와야할 게시물의 개수대로 랜덤하게 게시물을 가져옵니다
5. 이때, repository에서 반환하는 값은 [[카테고리가 활동인 게시물], [카테고리가 진로인 게시물]]과 같이 이중 리스트 구조이기에, service단에서 이를 단일 리스트로 변환하는 작업을 합니다

## 🧪 테스트 방법

## ⛳️ 고민한 점 || 궁굼한 점

## 🎯 리뷰 포인트

## 📁 레퍼런스
