### PR TITLE
feat: recent

### DIFF
--- a/docs/contents/contents.swagger.ts
+++ b/docs/contents/contents.swagger.ts
@@ -19,7 +19,7 @@ export function GetContentsDocs() {
     ApiOperation({
       summary: '게시물 전체조회 / 필터별 조회 API 입니다',
       description:
-        'Query가 들어오지 않을 시 전체를 조회하며, filter 이름의 쿼리 스트링이 들어올 시 카테고리가 일치하는 게시물만 조회됩니다',
+        'Query가 들어오지 않을 시 전체를 조회하며, filter 이름의 쿼리 스트링이 들어올 시 카테고리가 일치하는 게시물만 조회됩니다. 최근 업데이트 된 게시물 순서대로 정렬되어 조회됩니다.',
     }),
     RequireAccessToken(),
     ApiQuery({

--- a/src/domain/contents/repository/contents.repository.ts
+++ b/src/domain/contents/repository/contents.repository.ts
@@ -1,6 +1,5 @@
 import { CategoryFilter } from './../dtos/contents-request.dto';
-import { Injectable, BadRequestException } from '@nestjs/common';
-import { ContentCategories } from '@prisma/client';
+import { Injectable } from '@nestjs/common';
 import { ContentsDetailResponseDto } from 'src/domain/contents/dtos/contents-detail-response.dto';
 import { PrismaService } from 'src/global/prisma/prima.service';
 import { ContentsResponseDto } from '../dtos/contents-response.dto';
@@ -32,6 +31,9 @@ export class ContentsRepository {
           },
         },
       },
+      orderBy: {
+        created_at: 'desc',
+      },
     });
 
     return contents;
@@ -51,6 +53,9 @@ export class ContentsRepository {
             user,
           },
         },
+      },
+      orderBy: {
+        created_at: 'desc',
       },
     });
   }


### PR DESCRIPTION
### 관련 이슈가 있다면 적어주세요.

## 📌 개발 이유
탐색하기 탭이 최근 / 인기 게시물로만 나누어져있는 것을 확인하여, 기본 전체 조회 API를 최근 업데이트 순으로 가져오도록 수정했습니다

## 💻 수정 사항
repository에 orderby 추가

## 🧪 테스트 방법

## ⛳️ 고민한 점 || 궁굼한 점
기본 전체 조회 API에서 최근 게시물 순서대로 게시물을 불러온다면, 최근 업데이트된 게시물 관련해서 repository 코드를 새로 짤 이유가 없다고 생각하여 이 지점에서 어떻게 생각하시는 지 궁금합니다.

1. 전체 조희 할 때 사용하는 repository와 같게 연결한 후, 개수 제한이 필요하다면 service단에서 slice하여 전달한다
2. 같은 코드 중복 + take: n으로 새로 repository 코드를 짠다 (이 방법이 가장 비효율적인 것 같은데 인혁님 의견이 궁금해요)
3. 전체 조회 API를 그대로 사용하고 클라이언트 단에서 slice해서 사용하도록 양해를 구한다
## 🎯 리뷰 포인트

## 📁 레퍼런스
